### PR TITLE
Fix English spelling of the city of Kyiv

### DIFF
--- a/docs/en/venue.html
+++ b/docs/en/venue.html
@@ -209,7 +209,7 @@
             <div class="col-md-6">
               <h3>By bus</h3>
               <p class="text-justify">
-                All neighbouring capital cities Vienna, Prague, Budapest, Warsaw and Kiev have direct bus connections.
+                All neighbouring capital cities Vienna, Prague, Budapest, Warsaw and Kyiv have direct bus connections.
               </p>
               <p class="text-justify">
                 Most of the buses will bring you to the main bus station - Mlynske Nivy. It is currently located in temporary location, so dont
@@ -221,7 +221,7 @@
             <div class="col-md-6">
               <h3>By train</h3>
               <p class="text-justify">
-                All neighboring capital cities Vienna, Prague, Budapest, Warsaw and Kiev have direct train connections.
+                All neighboring capital cities Vienna, Prague, Budapest, Warsaw and Kyiv have direct train connections.
               </p>
               <p class="text-justify">
                 Once you arrive at the Bratislava train station (Bratislava hlavná stanica), leave the station through the main entrance.

--- a/messages.pot
+++ b/messages.pot
@@ -3904,7 +3904,7 @@ msgstr ""
 
 #: templates/venue.html:106
 msgid ""
-"All neighbouring capital cities Vienna, Prague, Budapest, Warsaw and Kiev"
+"All neighbouring capital cities Vienna, Prague, Budapest, Warsaw and Kyiv"
 " have direct bus connections."
 msgstr ""
 
@@ -3926,7 +3926,7 @@ msgstr ""
 
 #: templates/venue.html:118
 msgid ""
-"All neighboring capital cities Vienna, Prague, Budapest, Warsaw and Kiev "
+"All neighboring capital cities Vienna, Prague, Budapest, Warsaw and Kyiv "
 "have direct train connections."
 msgstr ""
 

--- a/templates/venue.html
+++ b/templates/venue.html
@@ -103,7 +103,7 @@
             <div class="col-md-6">
               <h3>{{ _('By bus') }}</h3>
               <p class="text-justify">
-                {{ _('All neighbouring capital cities Vienna, Prague, Budapest, Warsaw and Kiev have direct bus connections.') }}
+                {{ _('All neighbouring capital cities Vienna, Prague, Budapest, Warsaw and Kyiv have direct bus connections.') }}
               </p>
               <p class="text-justify">
                 {{ _('Most of the buses will bring you to the main bus station - Mlynske Nivy. It is currently located in temporary location, so don''t
@@ -115,7 +115,7 @@
             <div class="col-md-6">
               <h3>{{ _('By train') }}</h3>
               <p class="text-justify">
-                {{ _('All neighboring capital cities Vienna, Prague, Budapest, Warsaw and Kiev have direct train connections.') }}
+                {{ _('All neighboring capital cities Vienna, Prague, Budapest, Warsaw and Kyiv have direct train connections.') }}
               </p>
               <p class="text-justify">
                 {{ _('Once you arrive at the Bratislava train station (Bratislava hlavná stanica), leave the station through the main entrance.

--- a/translations/sk/LC_MESSAGES/messages.po
+++ b/translations/sk/LC_MESSAGES/messages.po
@@ -4710,7 +4710,7 @@ msgstr "Autobusom"
 
 #: templates/venue.html:106
 msgid ""
-"All neighbouring capital cities Vienna, Prague, Budapest, Warsaw and Kiev"
+"All neighbouring capital cities Vienna, Prague, Budapest, Warsaw and Kyiv"
 " have direct bus connections."
 msgstr ""
 "Všetky okolité hlavné mestá - Viedeň, Praha, Budapešť, Varšava aj Kyjev -"
@@ -4741,7 +4741,7 @@ msgstr "Vlakom"
 
 #: templates/venue.html:118
 msgid ""
-"All neighboring capital cities Vienna, Prague, Budapest, Warsaw and Kiev "
+"All neighboring capital cities Vienna, Prague, Budapest, Warsaw and Kyiv "
 "have direct train connections."
 msgstr ""
 "Z hlavných miest všetkých susedných krajín, teda z Viedne, Prahy, "


### PR DESCRIPTION
Hi,

I'm kindly asking you to change the spelling of the Ukrainian capital to the officially requested one. Thanks!

Refs:
* https://mfa.gov.ua/en/page/open/id/5418
* https://www.youtube.com/watch?v=brWD0ZP2s9A
* https://www.kyivpost.com/ukraine-politics/kyivnotkiev-campaign-asks-foreign-media-to-change-their-spelling-of-ukraines-capital.html