### PR TITLE
Fix Travis CI build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ ENV/
 
 # Vim
 *.swp
+
+# Visual Studio Code
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,18 @@
 language: python
 python: 
-- 3.7
+  - 3.7
 dist: xenial
+env:
+  - PIPENV_IGNORE_VIRTUALENVS=1
 install:
-- pip install pipenv
-- pipenv install --dev
+  - pip install pipenv
+  - pipenv install --dev
 script:
-- pipenv run pybabel extract -F babel.cfg -o messages.pot .
-- pipenv run pybabel update -i messages.pot -d translations
-- pipenv run pybabel compile -d translations
-- pipenv run python freezer.py
-- pylint pycon.py
-- pipenv check
+  - pipenv run pybabel extract -F babel.cfg -o messages.pot .
+  - pipenv run pybabel update -i messages.pot -d translations
+  - pipenv run pybabel compile -d translations
+  - pipenv run python freezer.py
+  - pylint pycon.py
+  - pipenv check
 notifications:
   slack: slovakpython:VrA4XJVmBVRsL5eCfDdE1cAr

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
   - pipenv run pybabel update -i messages.pot -d translations
   - pipenv run pybabel compile -d translations
   - pipenv run python freezer.py
-  - pylint pycon.py
+  - pipenv run pylint pycon.py
   - pipenv check
 notifications:
   slack: slovakpython:VrA4XJVmBVRsL5eCfDdE1cAr


### PR DESCRIPTION
This PR fixes the Travis CI build which was failing on `pipenv check` as the build was not running within the Pipenv virtual environment.
I also added the VS Code settings directory `.vscode` to the `.gitignore` file, so it won't be tracked in the project.